### PR TITLE
iceprog: Add write and read progress indication.

### DIFF
--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -966,10 +966,14 @@ int main(int argc, char **argv)
 					rc = fread(buffer, 1, page_size, f);
 					if (rc <= 0)
 						break;
+					fprintf(stderr, "                      \r");
+					fprintf(stderr, "addr 0x%06X %3ld%%\r", rw_offset + addr, addr / (file_size / 100));
 					flash_write_enable();
 					flash_prog(rw_offset + addr, buffer, rc);
 					flash_wait();
 				}
+				fprintf(stderr, "                      \r");
+				fprintf(stderr, "done.\n");
 
 				/* seek to the beginning for second pass */
 				fseek(f, 0, SEEK_SET);
@@ -984,9 +988,13 @@ int main(int argc, char **argv)
 			fprintf(stderr, "reading..\n");
 			for (int addr = 0; addr < read_size; addr += 256) {
 				uint8_t buffer[256];
+				fprintf(stderr, "                      \r");
+				fprintf(stderr, "addr 0x%06X %3d%%\r", rw_offset + addr, addr / (read_size / 100));
 				flash_read(rw_offset + addr, buffer, 256);
 				fwrite(buffer, read_size - addr > 256 ? 256 : read_size - addr, 1, f);
 			}
+			fprintf(stderr, "                      \r");
+			fprintf(stderr, "done.\n");
 		} else if (!erase_mode && !disable_verify) {
 			fprintf(stderr, "reading..\n");
 			for (int addr = 0; true; addr += 256) {
@@ -994,6 +1002,8 @@ int main(int argc, char **argv)
 				int rc = fread(buffer_file, 1, 256, f);
 				if (rc <= 0)
 					break;
+				fprintf(stderr, "                      \r");
+				fprintf(stderr, "addr 0x%06X %3ld%%\r", rw_offset + addr, addr / (file_size / 100));
 				flash_read(rw_offset + addr, buffer_flash, rc);
 				if (memcmp(buffer_file, buffer_flash, rc)) {
 					fprintf(stderr, "Found difference between flash and file!\n");
@@ -1001,6 +1011,7 @@ int main(int argc, char **argv)
 				}
 			}
 
+			fprintf(stderr, "                      \r");
 			fprintf(stderr, "VERIFY OK\n");
 		}
 


### PR DESCRIPTION
This patch adds progress indication for flash writing and reading.

I did not add it to the sram writing as that is pretty quick.

For large payloads progress indication is very important. Especially when the flash is used for more data than just bitstreams and we are writing megabytes of data into the flash.