### PR TITLE
docs/format.html: document bram/cram read-back commands

### DIFF
--- a/docs/format.html
+++ b/docs/format.html
@@ -47,8 +47,10 @@ The following commands are known:
 
 <table class="ctab">
 <tr><th>Opcode</th><th>Description</th></tr>
-<tr><td>0</td><td>payload=1: CRAM Data<br/>
-                  payload=3: BRAM Data<br/>
+<tr><td>0</td><td>payload=1: Write CRAM Data<br/>
+                  payload=2: Read BRAM Data<br/>
+                  payload=3: Write BRAM Data<br/>
+                  payload=4: Read BRAM Data<br/>
 		  payload=5: Reset CRC<br/>
 		  payload=6: Wakeup<br/>
 		  payload=8: Reboot</td></tr>
@@ -59,9 +61,9 @@ The following commands are known:
                   payload=0: low<br/>
                   payload=1: medium<br/>
                   payload=2: high</td></tr>
-<tr><td>6</td><td>Set bank width</td></tr>
-<tr><td>7</td><td>Set bank height</td></tr>
-<tr><td>8</td><td>Set bank offset</td></tr>
+<tr><td>6</td><td>Set bank width (16-bits, MSB first)</td></tr>
+<tr><td>7</td><td>Set bank height (16-bits, MSB first)</td></tr>
+<tr><td>8</td><td>Set bank offset (16-bits, MSB first)</td></tr>
 <tr><td>9</td><td>payload=0: Disable warm boot<br/>
                   payload=16: Enable cold boot<br/>
                   payload=32: Enable warm boot</td></tr>


### PR DESCRIPTION
The Lattice tools use these additional commands to read-back the BRAM
and CRAM after programming to validate that it was written correctly.
`iceprog` doesn't use this right now, so this is just for documentation
purposes.

Signed-off-by: Trammell Hudson <hudson@trmm.net>