### PR TITLE
icetime: Parse PCF files with -pullup and -pullup_resistor in set_io directives

### DIFF
--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -221,10 +221,20 @@ void read_pcf(const char *filename)
 		if (tok == nullptr || strcmp(tok, "set_io"))
 			continue;
 
+        bool skip_next = false;
 		std::vector<std::string> args;
 		while ((tok = strtok(nullptr, " \t\r\n")) != nullptr) {
+            if(skip_next) {
+                skip_next = false;
+                continue;
+            }
 			if (!strcmp(tok, "--warn-no-port"))
 				continue;
+            if (!strcmp(tok, "-pullup") || !strcmp(tok, "-pullup_resistor")) {
+                skip_next = true; // skip argument
+                continue;
+            }
+
 			args.push_back(tok);
 		}
 

--- a/icetime/icetime.cc
+++ b/icetime/icetime.cc
@@ -221,19 +221,19 @@ void read_pcf(const char *filename)
 		if (tok == nullptr || strcmp(tok, "set_io"))
 			continue;
 
-        bool skip_next = false;
+		bool skip_next = false;
 		std::vector<std::string> args;
 		while ((tok = strtok(nullptr, " \t\r\n")) != nullptr) {
-            if(skip_next) {
-                skip_next = false;
-                continue;
-            }
+			if(skip_next) {
+				skip_next = false;
+				continue;
+			}
 			if (!strcmp(tok, "--warn-no-port"))
 				continue;
-            if (!strcmp(tok, "-pullup") || !strcmp(tok, "-pullup_resistor")) {
-                skip_next = true; // skip argument
-                continue;
-            }
+			if (!strcmp(tok, "-pullup") || !strcmp(tok, "-pullup_resistor")) {
+				skip_next = true; // skip argument
+				continue;
+			}
 
 			args.push_back(tok);
 		}


### PR DESCRIPTION
According to https://github.com/YosysHQ/nextpnr/blob/master/docs/ice40.md it is possible to specify pullups with set_io:

```
set_io [-nowarn] [-pullup yes|no] [-pullup_resistor 3P3K|6P8K|10K|100K] port pin
```
Currently, icetime does not discard these additional tokens, which leads to a failed assertion that expects exactly two tokens pwer set_io-line. This pull request includes logic to discard surplus tokens.