### PR TITLE
Exit with error when no RAM contents were replaced.

### DIFF
--- a/icebram/icebram.cc
+++ b/icebram/icebram.cc
@@ -384,6 +384,10 @@ int main(int argc, char **argv)
 	if (verbose)
 		fprintf(stderr, "Found and replaced %d instances of the memory.\n", max_replace_cnt);
 
+	if (max_replace_cnt == 0) {
+		fprintf(stderr, "No memory instances were replaced.\n");
+		exit(2);
+	}
 
 	// -------------------------------------------------------
 	// Write ascfile to stdout


### PR DESCRIPTION
When `icebram` is called to replace RAM contents but no RAM contents are replaced, it currently simply exits. This indicates a build failure. (Why else would anyone call `icebram`?)

This becomes more important due to [this issue](https://github.com/YosysHQ/icestorm/issues/301), where `icebram` fails after switching to a new `memory_libmap`. Existing projects that used to build just fine are currently creating broken bitstreams, and unless the `-v` flag is used, no warnings are generated. (Not that anyone actually looks at warnings...)

Ultimately, `icebram` should be fixed so that it works with the new `memory_libmap`, but until that's done, it should at least exit with any error instead, which is what this PR does.