### PR TITLE
icebram: fix WebAssembly compatibility

### DIFF
--- a/icebram/icebram.cc
+++ b/icebram/icebram.cc
@@ -19,9 +19,9 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 #include <unistd.h>
 #include <sys/time.h>
-#include <bits/stdc++.h>
 
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
cc @smunaut 

I've removed the use of exceptions. In one case there's no change but in others it actually improves user experience because there was no `try` block in main and so errors in parsing hex files would look like this:

```
Can't parse line 1 of x.hex: 7d*
terminate called after throwing an instance of 'std::runtime_error'
  what():  Invalid input file
Aborted
```

After this PR, it looks like:
```
Can't parse line 1 of x.hex: 7d*
```