### PR TITLE
Update tillitis--iceprog to work with faster USB interface

### DIFF
--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -8,8 +8,8 @@ else
 LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
 CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
 
-CFLAGS += -lhidapi-libusb
-LDLIBS += -lhidapi-libusb
+CFLAGS += -llibusb-1.0
+LDLIBS += -lusb-1.0
 endif
 
 all: $(PROGRAM_PREFIX)iceprog$(EXE)

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -11,7 +11,7 @@ endif
 
 all: $(PROGRAM_PREFIX)iceprog$(EXE)
 
-$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o
+$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o
 	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 
 install: all

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -7,11 +7,14 @@ CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors
 else
 LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
 CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
+
+CFLAGS += -lhidapi-libusb
+LDLIBS += -lhidapi-libusb
 endif
 
 all: $(PROGRAM_PREFIX)iceprog$(EXE)
 
-$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o
+$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o rpi_pico_interface.o
 	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 
 install: all

--- a/iceprog/ftdi_interface.c
+++ b/iceprog/ftdi_interface.c
@@ -1,0 +1,46 @@
+#include "ftdi_interface.h"
+#include "mpsse.h"
+#include <stdio.h>
+
+static void set_cs_creset(int cs_b, int creset_b)
+{
+	uint8_t gpio = 0;
+	uint8_t direction = 0x03;
+
+	if (!cs_b) {
+		// ADBUS4 (GPIOL0)
+		direction |= 0x10;
+	}
+
+	if (!creset_b) {
+		// ADBUS7 (GPIOL3)
+		direction |= 0x80;
+	}
+
+	mpsse_set_gpio(gpio, direction);
+}
+
+static bool get_cdone(void)
+{
+	// ADBUS6 (GPIOL2)
+	return (mpsse_readb_low() & 0x40) != 0;
+}
+
+const interface_t ftdi_interface = {
+	.close = mpsse_close,
+	.error = mpsse_error,
+
+	.set_cs_creset = set_cs_creset,
+	.get_cdone = get_cdone,
+
+	.send_spi = mpsse_send_spi,
+	.xfer_spi = mpsse_xfer_spi,
+	.xfer_spi_bits = mpsse_xfer_spi_bits,
+
+	.send_dummy_bytes = mpsse_send_dummy_bytes,
+	.send_dummy_bit = mpsse_send_dummy_bit,
+};
+
+void ftdi_interface_init(int ifnum, const char *devstr, bool slow_clock) {
+	mpsse_init(ifnum, devstr, slow_clock);
+}

--- a/iceprog/ftdi_interface.h
+++ b/iceprog/ftdi_interface.h
@@ -1,0 +1,13 @@
+#ifndef FTDI_INTERFACE_H
+#define FTDI_INTERFACE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "interface.h"
+
+
+extern const interface_t ftdi_interface;
+
+void ftdi_interface_init(int ifnum, const char *devstr, bool slow_clock);
+
+#endif

--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -376,7 +376,9 @@ static void flash_wait()
 		flash_chip_deselect();
 
 		if ((data[1] & 0x01) == 0) {
-			if (count < 2) {
+// TODO: Why check the return flag multiple times?
+//			if (count < 2) {
+			if (false) {
 				count++;
 				if (verbose) {
 					fprintf(stderr, "r");

--- a/iceprog/iceprog.c
+++ b/iceprog/iceprog.c
@@ -43,6 +43,7 @@
 #include "mpsse.h"
 #include "interface.h"
 #include "ftdi_interface.h"
+#include "rpi_pico_interface.h"
 
 static bool verbose = false;
 
@@ -835,8 +836,11 @@ int main(int argc, char **argv)
 
 	fprintf(stderr, "init..\n");
 
-	ftdi_interface_init(ifnum, devstr, slow_clock);
-	interface = &ftdi_interface;
+//	ftdi_interface_init(ifnum, devstr, slow_clock);
+//	interface = &ftdi_interface;
+
+	rpi_pico_interface_init();
+	interface = &rpi_pico_interface;
 
 	fprintf(stderr, "cdone: %s\n", interface->get_cdone() ? "high" : "low");
 

--- a/iceprog/interface.h
+++ b/iceprog/interface.h
@@ -1,0 +1,19 @@
+#ifndef INTERFACE_H
+#define INTERFACE_H
+
+// Interface
+typedef struct {
+	void (*close)(void);
+	void (*error)(int status);
+
+	void (*set_cs_creset)(int cs_b, int creset_b);
+	bool (*get_cdone)(void);
+
+	void (*send_spi)(uint8_t *data, int n);
+	void (*xfer_spi)(uint8_t *data, int n);
+	uint8_t (*xfer_spi_bits)(uint8_t data, int n);
+	void (*send_dummy_bytes)(uint8_t n);  // probably remvoe this
+	void (*send_dummy_bit)(void); // probably remove this
+} interface_t;
+
+#endif

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -115,7 +115,7 @@ static bool pin_read(uint8_t pin) {
     return (pins & (1<<pin));
 }
 
-#define MAX_BYTES_PER_TRANSFER (64-9)
+#define MAX_BYTES_PER_TRANSFER (64-8)
 
 static void bitbang_spi(
     uint8_t sck_pin,
@@ -184,7 +184,14 @@ static void bitbang_spi(
 
 // TODO
 static void close() {
-//    pin_write(PIN_POWER, false);
+//    pin_set_direction(PIN_POWER, true);
+    pin_set_direction(PIN_SCK, false);
+    pin_set_direction(PIN_MOSI, false);
+    pin_set_direction(PIN_SS, false);
+    pin_set_direction(PIN_MISO, false);
+    pin_set_direction(PIN_CRESET, false);
+    pin_set_direction(PIN_CDONE, false);
+
     led_set(false);
     printf("closing\n");
 

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -1,0 +1,298 @@
+#include "rpi_pico_interface.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <hidapi/hidapi.h>
+
+#define VENDOR_ID   0xcafe
+#define PRODUCT_ID  0x4004
+
+static hid_device * handle;
+
+static void led_set(bool value) {
+    
+    uint8_t buf[3];
+    buf[0] = 0;
+    buf[1] = 0x00;
+    buf[2] = (value ? 1:0);
+
+//    printf("led_set [");
+//    for(int i = 0; i < sizeof(buf); i++) {
+//        printf("%02x, ", buf[i]);
+//    }
+//    printf("]\n");
+
+    hid_write(handle, buf, sizeof(buf));
+}
+
+static void pin_set_direction(uint8_t pin, bool direction) {
+    const uint32_t mask = (1<<pin);
+    const uint32_t val = ((direction?1:0)<<pin);
+
+    uint8_t buf[10];
+    buf[0] = 0;
+    buf[1] = 0x10;
+    buf[2] = (mask >> 24) & 0xff;
+    buf[3] = (mask >> 16) & 0xff;
+    buf[4] = (mask >> 8) & 0xff;
+    buf[5] = (mask >> 0) & 0xff;
+    buf[6] = (val >> 24) & 0xff;
+    buf[7] = (val >> 16) & 0xff;
+    buf[8] = (val >> 8) & 0xff;
+    buf[9] = (val >> 0) & 0xff;
+
+//    printf("pin_set_direction [");
+//    for(int i = 0; i < sizeof(buf); i++) {
+//        printf("%02x, ", buf[i]);
+//    }
+//    printf("]\n");
+
+    hid_write(handle, buf, sizeof(buf));
+}
+
+static void pinmask_write(uint32_t mask, uint32_t val) {
+    uint8_t buf[10];
+    buf[0] = 0;
+    buf[1] = 0x20;
+    buf[2] = (mask >> 24) & 0xff;
+    buf[3] = (mask >> 16) & 0xff;
+    buf[4] = (mask >> 8) & 0xff;
+    buf[5] = (mask >> 0) & 0xff;
+    buf[6] = (val >> 24) & 0xff;
+    buf[7] = (val >> 16) & 0xff;
+    buf[8] = (val >> 8) & 0xff;
+    buf[9] = (val >> 0) & 0xff;
+
+//    printf("pin_write [");
+//    for(int i = 0; i < sizeof(buf); i++) {
+//        printf("%02x, ", buf[i]);
+//    }
+//    printf("]\n");
+
+    hid_write(handle, buf, sizeof(buf));
+
+}
+
+static void pin_write(uint8_t pin, bool value) {
+    const uint32_t mask = (1<<pin);
+    const uint32_t val = ((value?1:0)<<pin);
+
+    pinmask_write(mask, val);
+}
+
+static bool pin_read(uint8_t pin) {
+    uint8_t buf[2];
+    buf[0] = 0;
+    buf[1] = 0x30;
+
+//    printf("pin_read [");
+//    for(int i = 0; i < sizeof(buf); i++) {
+//        printf("%02x, ", buf[i]);
+//    }
+//    printf("]\n");
+
+    hid_write(handle, buf, sizeof(buf));
+
+    uint8_t ret_buf[5];
+    const int bytes_read = hid_read_timeout(handle, ret_buf, sizeof(ret_buf), 400);
+    if(bytes_read != sizeof(ret_buf)) {
+        printf("error reading, got:%i\n", bytes_read);
+        exit(1);
+    }
+
+//    printf("  ret=[");
+//    for(int i = 0; i < sizeof(ret_buf); i++) {
+//        printf("%02x, ", ret_buf[i]);
+//    }
+//    printf("]\n");
+
+    uint32_t pins =
+        (ret_buf[1] << 24)
+        | (ret_buf[2] << 16)
+        | (ret_buf[3] << 8)
+        | (ret_buf[4] << 0);
+
+    return (pins & (1<<pin));
+}
+
+#define MAX_BYTES_PER_TRANSFER 50
+
+static void bitbang_spi(
+    uint8_t sck_pin,
+    uint8_t mosi_pin,
+    uint8_t miso_pin,
+    uint32_t bit_count,
+    uint8_t* buffer) {
+
+    const int byte_count = ((bit_count + 7) / 8);
+    if(byte_count > MAX_BYTES_PER_TRANSFER) {
+        printf("bit count too high\n");
+        exit(1);
+    }
+
+//    printf("bitbang_spi byte_count:%i bit_count:%i\n", byte_count, bit_count);
+
+    uint8_t buf[9+MAX_BYTES_PER_TRANSFER];
+    memset(buf, 0xFF, sizeof(buf));
+
+    buf[0] = 0;
+    buf[1] = 0x40;
+    buf[2] = sck_pin;
+    buf[3] = mosi_pin;
+    buf[4] = miso_pin;
+    buf[5] = (bit_count >> 24) & 0xff;
+    buf[6] = (bit_count >> 16) & 0xff;
+    buf[7] = (bit_count >> 8) & 0xff;
+    buf[8] = (bit_count >> 0) & 0xff;
+
+    
+    memcpy(&buf[9], buffer, byte_count); // TODO: memory length
+
+//    printf("  send:[");
+//    for(int i = 0; i < (8+byte_count); i++) {
+//        printf("%02x, ", buf[i]);
+//    }
+//    printf("]\n");
+
+    uint8_t ret_buf[64];
+
+    hid_write(handle, buf, sizeof(buf));
+
+    const int bytes_read = hid_read_timeout(handle, ret_buf, 64, 4000);
+    if(bytes_read != 64) {
+        printf("error reading, got:%i\n", bytes_read);
+        exit(1);
+    }
+
+//    printf("  receive:[");
+//    for(int i = 0; i < (5+byte_count); i++) {
+//        printf("%02x, ", ret_buf[i]);
+//    }
+//    printf("]\n");
+    memcpy(buffer, &ret_buf[5], byte_count);
+}
+
+#define PIN_POWER 7
+#define PIN_SCK 10
+#define PIN_MOSI 13
+#define PIN_SS 12
+#define PIN_MISO 11
+#define PIN_CRESET 14
+#define PIN_CDONE 15
+
+// ********* iceprog API ****************
+
+// TODO
+static void close() {
+//    pin_write(PIN_POWER, false);
+    led_set(false);
+    printf("closing\n");
+
+    hid_close(handle);
+    handle = NULL;
+}
+
+// TODO
+static void error(int status) {
+    close();
+    exit(status);
+}
+
+// TODO
+static void set_cs_creset(int cs_b, int creset_b) {
+    pinmask_write(
+        (1<<PIN_SS) | (1<PIN_CRESET),
+        ((cs_b>0?1:0)<<PIN_SS) | ((creset_b>0?1:0)<<PIN_CRESET)
+    );
+}
+
+// TODO
+static bool get_cdone(void) { 
+    return pin_read(PIN_CDONE);
+}
+
+// TODO
+static uint8_t xfer_spi_bits(uint8_t data, int n) {
+    uint8_t buf = data;
+    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, n, &buf);
+
+    return buf;
+}
+
+// TODO
+static void xfer_spi(uint8_t *data, int n) {
+//    printf("xfer_spi %i\n",n);
+    for(int byte_index = 0; byte_index < n;) {
+        int bytes_to_transfer = n - byte_index;
+        if(bytes_to_transfer > MAX_BYTES_PER_TRANSFER) {
+            bytes_to_transfer = MAX_BYTES_PER_TRANSFER;
+        }
+//      printf(" byte_index:%i bytes_to_transfer:%i\n", byte_index, bytes_to_transfer);
+
+        bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, bytes_to_transfer*8, data+byte_index);
+        byte_index += bytes_to_transfer;
+    }
+}
+
+// TODO
+static void send_spi(uint8_t *data, int n) {
+    uint8_t buf[n];
+    memcpy(buf,data,sizeof(buf));
+    xfer_spi(buf,n);
+}
+
+// TODO
+static void send_dummy_bytes(uint8_t n) {
+    uint8_t buf[n];
+    memset(buf, 0, sizeof(buf));
+    xfer_spi(buf, sizeof(buf));
+}
+
+
+// TODO
+static void send_dummy_bit(void) {
+    xfer_spi_bits(0, 1);
+}
+
+
+const interface_t rpi_pico_interface = {
+	.close = close,
+	.error = error,
+
+	.set_cs_creset = set_cs_creset,
+	.get_cdone = get_cdone,
+
+	.send_spi = send_spi,
+	.xfer_spi = xfer_spi,
+	.xfer_spi_bits = xfer_spi_bits,
+
+	.send_dummy_bytes = send_dummy_bytes,
+	.send_dummy_bit = send_dummy_bit,
+};
+
+void rpi_pico_interface_init() {
+    hid_init();
+    
+    handle = hid_open( VENDOR_ID, PRODUCT_ID, NULL);
+    if(handle == NULL) {
+        printf("Failure!\n");
+
+        hid_exit();
+        exit(-1);
+    }
+
+    led_set(true);
+
+
+    pin_set_direction(PIN_POWER, true);
+    pin_set_direction(PIN_SCK, true);
+    pin_set_direction(PIN_MOSI, true);
+    pin_set_direction(PIN_SS, true);
+    pin_set_direction(PIN_MISO, false);
+    pin_set_direction(PIN_CRESET, true);
+    pin_set_direction(PIN_CDONE, false);
+
+    pin_write(PIN_POWER, true);
+}
+
+// ********* API ****************

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -160,13 +160,15 @@ static void set_spi_pins(
     uint8_t sck_pin,
     uint8_t cs_pin,
     uint8_t mosi_pin,
-    uint8_t miso_pin) {
+    uint8_t miso_pin,
+    uint8_t speed_mhz) {
 
-    uint8_t buf[4];
+    uint8_t buf[5];
     buf[0] = sck_pin;
     buf[1] = cs_pin;
     buf[2] = mosi_pin;
     buf[3] = miso_pin;
+    buf[4] = speed_mhz;
 
     usb_write(FLASHER_REQUEST_SPI_PINS_SET, buf, sizeof(buf));
 }
@@ -347,7 +349,7 @@ void rpi_pico_interface_init() {
 
     pin_write(PIN_POWER, true);
 
-    set_spi_pins(PIN_SCK, PIN_SS, PIN_MOSI, PIN_MISO);
+    set_spi_pins(PIN_SCK, PIN_SS, PIN_MOSI, PIN_MISO, 15);
 }
 
 // ********* API ****************

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -115,7 +115,7 @@ static bool pin_read(uint8_t pin) {
     return (pins & (1<<pin));
 }
 
-#define MAX_BYTES_PER_TRANSFER 50
+#define MAX_BYTES_PER_TRANSFER (64-9)
 
 static void bitbang_spi(
     uint8_t sck_pin,

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -2,19 +2,54 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <hidapi/hidapi.h>
+#include <libusb-1.0/libusb.h>
 
-#define VENDOR_ID   0xcafe
-#define PRODUCT_ID  0x4004
+#define VENDOR_ID 0xCAFE
+#define PRODUCT_ID 0x4010
 
-static hid_device * handle;
+//static hid_device * handle;
+
+libusb_context *ctx=NULL;
+struct libusb_device_handle *devhaccess;
+
+// https://github.com/jerome-labidurie/avr/blob/master/fpusb/host-libusb/fpusb.c
+void usb_exit ( int sig )
+{
+   libusb_release_interface (devhaccess, 0);
+   libusb_close (devhaccess);
+   libusb_exit (ctx);
+   exit(sig);
+}
+
+int usb_write(uint8_t request, uint8_t* data, int length) {
+   return libusb_control_transfer ( devhaccess,
+                                   0x40,
+                                   request,
+                                   0,
+                                   0,
+                                   data,
+                                   length,
+                                   1000);
+
+}
+
+int usb_read(uint8_t request, uint8_t* data, int length) {
+   return libusb_control_transfer ( devhaccess,
+                                   0xC0,
+                                   request,
+                                   0,
+                                   0,
+                                   data,
+                                   length,
+                                   1000);
+}
 
 static void led_set(bool value) {
     
-    uint8_t buf[3];
-    buf[0] = 0;
-    buf[1] = 0x00;
-    buf[2] = (value ? 1:0);
+//    uint8_t buf[3];
+//    buf[0] = 0;
+//    buf[1] = 0x00;
+//    buf[2] = (value ? 1:0);
 
 //    printf("led_set [");
 //    for(int i = 0; i < sizeof(buf); i++) {
@@ -22,46 +57,36 @@ static void led_set(bool value) {
 //    }
 //    printf("]\n");
 
-    hid_write(handle, buf, sizeof(buf));
+//    hid_write(handle, buf, sizeof(buf));
 }
 
 static void pin_set_direction(uint8_t pin, bool direction) {
     const uint32_t mask = (1<<pin);
     const uint32_t val = ((direction?1:0)<<pin);
 
-    uint8_t buf[10];
-    buf[0] = 0;
-    buf[1] = 0x10;
-    buf[2] = (mask >> 24) & 0xff;
-    buf[3] = (mask >> 16) & 0xff;
-    buf[4] = (mask >> 8) & 0xff;
-    buf[5] = (mask >> 0) & 0xff;
-    buf[6] = (val >> 24) & 0xff;
-    buf[7] = (val >> 16) & 0xff;
-    buf[8] = (val >> 8) & 0xff;
-    buf[9] = (val >> 0) & 0xff;
+    uint8_t buf[8];
+    buf[0] = (mask >> 24) & 0xff;
+    buf[1] = (mask >> 16) & 0xff;
+    buf[2] = (mask >> 8) & 0xff;
+    buf[3] = (mask >> 0) & 0xff;
+    buf[4] = (val >> 24) & 0xff;
+    buf[5] = (val >> 16) & 0xff;
+    buf[6] = (val >> 8) & 0xff;
+    buf[7] = (val >> 0) & 0xff;
 
-//    printf("pin_set_direction [");
-//    for(int i = 0; i < sizeof(buf); i++) {
-//        printf("%02x, ", buf[i]);
-//    }
-//    printf("]\n");
-
-    hid_write(handle, buf, sizeof(buf));
+    usb_write(0x10, buf, sizeof(buf));
 }
 
 static void pinmask_write(uint32_t mask, uint32_t val) {
-    uint8_t buf[10];
-    buf[0] = 0;
-    buf[1] = 0x20;
-    buf[2] = (mask >> 24) & 0xff;
-    buf[3] = (mask >> 16) & 0xff;
-    buf[4] = (mask >> 8) & 0xff;
-    buf[5] = (mask >> 0) & 0xff;
-    buf[6] = (val >> 24) & 0xff;
-    buf[7] = (val >> 16) & 0xff;
-    buf[8] = (val >> 8) & 0xff;
-    buf[9] = (val >> 0) & 0xff;
+    uint8_t buf[8];
+    buf[0] = (mask >> 24) & 0xff;
+    buf[1] = (mask >> 16) & 0xff;
+    buf[2] = (mask >> 8) & 0xff;
+    buf[3] = (mask >> 0) & 0xff;
+    buf[4] = (val >> 24) & 0xff;
+    buf[5] = (val >> 16) & 0xff;
+    buf[6] = (val >> 8) & 0xff;
+    buf[7] = (val >> 0) & 0xff;
 
 //    printf("pin_write [");
 //    for(int i = 0; i < sizeof(buf); i++) {
@@ -69,8 +94,7 @@ static void pinmask_write(uint32_t mask, uint32_t val) {
 //    }
 //    printf("]\n");
 
-    hid_write(handle, buf, sizeof(buf));
-
+    usb_write(0x20, buf, sizeof(buf));
 }
 
 static void pin_write(uint8_t pin, bool value) {
@@ -81,24 +105,8 @@ static void pin_write(uint8_t pin, bool value) {
 }
 
 static bool pin_read(uint8_t pin) {
-    uint8_t buf[2];
-    buf[0] = 0;
-    buf[1] = 0x30;
-
-//    printf("pin_read [");
-//    for(int i = 0; i < sizeof(buf); i++) {
-//        printf("%02x, ", buf[i]);
-//    }
-//    printf("]\n");
-
-    hid_write(handle, buf, sizeof(buf));
-
-    uint8_t ret_buf[5];
-    const int bytes_read = hid_read_timeout(handle, ret_buf, sizeof(ret_buf), 400);
-    if(bytes_read != sizeof(ret_buf)) {
-        printf("error reading, got:%i\n", bytes_read);
-        exit(1);
-    }
+    uint8_t ret_buf[4];
+    usb_read(0x30, ret_buf, sizeof(ret_buf));
 
 //    printf("  ret=[");
 //    for(int i = 0; i < sizeof(ret_buf); i++) {
@@ -107,69 +115,49 @@ static bool pin_read(uint8_t pin) {
 //    printf("]\n");
 
     uint32_t pins =
-        (ret_buf[1] << 24)
-        | (ret_buf[2] << 16)
-        | (ret_buf[3] << 8)
-        | (ret_buf[4] << 0);
+        (ret_buf[0] << 24)
+        | (ret_buf[1] << 16)
+        | (ret_buf[2] << 8)
+        | (ret_buf[3] << 0);
 
     return (pins & (1<<pin));
 }
 
-#define MAX_BYTES_PER_TRANSFER (64-8)
+//#define MAX_BYTES_PER_TRANSFER (256-7)
+#define MAX_BYTES_PER_TRANSFER (1024-8)
 
 static void bitbang_spi(
     uint8_t sck_pin,
     uint8_t mosi_pin,
     uint8_t miso_pin,
     uint32_t bit_count,
-    uint8_t* buffer) {
+    uint8_t* buf_out,
+    uint8_t* buf_in) {
 
-    const int byte_count = ((bit_count + 7) / 8);
+    const uint32_t byte_count = ((bit_count + 7) / 8);
     if(byte_count > MAX_BYTES_PER_TRANSFER) {
         printf("bit count too high\n");
         exit(1);
     }
 
-//    printf("bitbang_spi byte_count:%i bit_count:%i\n", byte_count, bit_count);
-
-    uint8_t buf[9+MAX_BYTES_PER_TRANSFER];
+    uint8_t buf[7+MAX_BYTES_PER_TRANSFER];
     memset(buf, 0xFF, sizeof(buf));
 
-    buf[0] = 0;
-    buf[1] = 0x40;
-    buf[2] = sck_pin;
-    buf[3] = mosi_pin;
-    buf[4] = miso_pin;
-    buf[5] = (bit_count >> 24) & 0xff;
-    buf[6] = (bit_count >> 16) & 0xff;
-    buf[7] = (bit_count >> 8) & 0xff;
-    buf[8] = (bit_count >> 0) & 0xff;
+    buf[0] = sck_pin;
+    buf[1] = mosi_pin;
+    buf[2] = miso_pin;
+    buf[3] = (bit_count >> 24) & 0xff;
+    buf[4] = (bit_count >> 16) & 0xff;
+    buf[5] = (bit_count >> 8) & 0xff;
+    buf[6] = (bit_count >> 0) & 0xff;
 
-    
-    memcpy(&buf[9], buffer, byte_count); // TODO: memory length
+    memcpy(&buf[7], buf_out, byte_count);
 
-//    printf("  send:[");
-//    for(int i = 0; i < (8+byte_count); i++) {
-//        printf("%02x, ", buf[i]);
-//    }
-//    printf("]\n");
+    usb_write(0x40, buf, byte_count+7);
 
-    uint8_t ret_buf[64];
-
-    hid_write(handle, buf, sizeof(buf));
-
-    const int bytes_read = hid_read_timeout(handle, ret_buf, 64, 4000);
-    if(bytes_read != 64) {
-        printf("error reading, got:%i\n", bytes_read);
-        exit(1);
+    if(buf_in != NULL) {
+        usb_read(0x40, buf_in, byte_count);
     }
-
-//    printf("  receive:[");
-//    for(int i = 0; i < (5+byte_count); i++) {
-//        printf("%02x, ", ret_buf[i]);
-//    }
-//    printf("]\n");
-    memcpy(buffer, &ret_buf[5], byte_count);
 }
 
 #define PIN_POWER 7
@@ -195,8 +183,9 @@ static void close() {
     led_set(false);
     printf("closing\n");
 
-    hid_close(handle);
-    handle = NULL;
+   libusb_release_interface (devhaccess, 0);
+   libusb_close (devhaccess);
+   libusb_exit (ctx);
 }
 
 // TODO
@@ -221,44 +210,33 @@ static bool get_cdone(void) {
 // TODO
 static uint8_t xfer_spi_bits(uint8_t data, int n) {
     uint8_t buf = data;
-    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, n, &buf);
+    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, n, &buf, &buf);
 
     return buf;
 }
 
 // TODO
 static void xfer_spi(uint8_t *data, int n) {
-//    printf("xfer_spi %i\n",n);
-    for(int byte_index = 0; byte_index < n;) {
-        int bytes_to_transfer = n - byte_index;
-        if(bytes_to_transfer > MAX_BYTES_PER_TRANSFER) {
-            bytes_to_transfer = MAX_BYTES_PER_TRANSFER;
-        }
-//      printf(" byte_index:%i bytes_to_transfer:%i\n", byte_index, bytes_to_transfer);
-
-        bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, bytes_to_transfer*8, data+byte_index);
-        byte_index += bytes_to_transfer;
-    }
+    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, n*8, data, data);
 }
 
 // TODO
 static void send_spi(uint8_t *data, int n) {
-    uint8_t buf[n];
-    memcpy(buf,data,sizeof(buf));
-    xfer_spi(buf,n);
+    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, n*8, data, NULL);
 }
 
 // TODO
 static void send_dummy_bytes(uint8_t n) {
     uint8_t buf[n];
     memset(buf, 0, sizeof(buf));
-    xfer_spi(buf, sizeof(buf));
+    send_spi(buf, sizeof(buf));
 }
 
 
 // TODO
 static void send_dummy_bit(void) {
-    xfer_spi_bits(0, 1);
+    uint8_t buf = 0;
+    bitbang_spi(PIN_SCK, PIN_MOSI, PIN_MISO, 1, &buf, NULL);
 }
 
 
@@ -278,15 +256,34 @@ const interface_t rpi_pico_interface = {
 };
 
 void rpi_pico_interface_init() {
-    hid_init();
-    
-    handle = hid_open( VENDOR_ID, PRODUCT_ID, NULL);
-    if(handle == NULL) {
-        printf("Failure!\n");
+    if (libusb_init(&ctx) != 0) {
+        printf("failure!\n");
 
-        hid_exit();
         exit(-1);
     }
+
+    if ( (devhaccess = libusb_open_device_with_vid_pid (ctx, VENDOR_ID, PRODUCT_ID)) == 0) {
+        printf("libusb_open_device_with_vid_pid error\n");
+        libusb_exit(ctx);
+        exit(-1);
+    }
+
+   if (libusb_claim_interface (devhaccess, 0) != 0) {
+      perror ("libusb_claim_interface error");
+      usb_exit(-1);
+   }
+
+    
+
+//    hid_init();
+    
+//    handle = hid_open( VENDOR_ID, PRODUCT_ID, NULL);
+//    if(handle == NULL) {
+//        printf("failure!\n");
+//
+//        hid_exit();
+//        exit(-1);
+//    }
 
     led_set(true);
 

--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -286,13 +286,14 @@ void rpi_pico_interface_init() {
         exit(-1);
     }
 
-   if (libusb_claim_interface (devhaccess, 0) != 0) {
-      perror ("libusb_claim_interface error");
-      usb_exit(-1);
-   }
+    if (libusb_claim_interface (devhaccess, 0) != 0) {
+        perror ("libusb_claim_interface error");
+        usb_exit(-1);
+    }
+
+    printf("This iceprog has raw power!\n");
 
     led_set(true);
-
 
     pin_set_direction(PIN_POWER, true);
     pin_set_direction(PIN_SCK, true);

--- a/iceprog/rpi_pico_interface.h
+++ b/iceprog/rpi_pico_interface.h
@@ -1,0 +1,13 @@
+#ifndef RPI_PICO_INTERFACE_H
+#define RPI_PICO_INTERFACE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "interface.h"
+
+
+extern const interface_t rpi_pico_interface;
+
+void rpi_pico_interface_init();
+
+#endif


### PR DESCRIPTION
Previously, the shipped USB programmer presented itself as a HID device. This had a major impact on programming speed. These changes update the pico programming interface to work with a faster control transfer-based interface.