### PR TITLE
Some fixes for examples/ used by Debian packaging 

### DIFF
--- a/examples/icemulti/Makefile
+++ b/examples/icemulti/Makefile
@@ -1,3 +1,5 @@
+all: config.bin
+
 prog: config.bin
 	sudo iceprog config.bin
 

--- a/examples/up5k_rgb/rgb.pcf
+++ b/examples/up5k_rgb/rgb.pcf
@@ -1,3 +1,4 @@
+set_frequency clk 32
 set_io RGB0 39
 set_io RGB1 40
 set_io RGB2 41


### PR DESCRIPTION
Hi,

This fixes some errors in the examples/ pojects. In the [Debian packaging of icestorm](https://salsa.debian.org/electronics-team/fpga-icestorm) we build the examples as part of test-suite so failures there hold up releasing new versions.

Thanks,
--Daniel

