### PR TITLE
[icepll] Fixed the generated PLL lint errors from issue #352

### DIFF
--- a/icepll/icepll.cc
+++ b/icepll/icepll.cc
@@ -413,7 +413,15 @@ int main(int argc, char **argv)
 						"\t\t.RESETB(1'b1),\n"
 						"\t\t.BYPASS(1'b0),\n"
 						"\t\t.%s(clock_in),\n"
-						"\t\t.PLLOUTCORE(clock_out)\n"
+						"\t\t.PLLOUTCORE(clock_out),\n\n"
+						"\t\t/* Unused */\n"
+						"\t\t.PLLOUTGLOBAL(),\n"
+						"\t\t.EXTFEEDBACK(),\n"
+						"\t\t.LATCHINPUTVALUE(),\n"
+						"\t\t.SDO(),\n"
+						"\t\t.SDI(),\n"
+						"\t\t.SCLK(),\n"
+						"\t\t.DYNAMICDELAY()\n"
 						"\t\t);\n\n", (pad ? "PACKAGEPIN":"REFERENCECLK")
 					);
 


### PR DESCRIPTION
This PR fixes the lint error reported in issue #352 by specifying explicitly the unused signals in the instantiation of SB_PLL40_CORE. The generated code was tested successfully with an actual Alhambra-ii FPGA board.

The new command generates this code (notice the added 'unused' section):

pll.v
```
/**
 * PLL configuration
 *
 * This Verilog module was generated automatically
 * using the icepll tool from the IceStorm project.
 * Use at your own risk.
 *
 * Given input frequency:        12.000 MHz
 * Requested output frequency:   48.000 MHz
 * Achieved output frequency:    48.000 MHz
 */

module pll(
	input  clock_in,
	output clock_out,
	output locked
	);

SB_PLL40_CORE #(
		.FEEDBACK_PATH("SIMPLE"),
		.DIVR(4'b0000),		// DIVR =  0
		.DIVF(7'b0111111),	// DIVF = 63
		.DIVQ(3'b100),		// DIVQ =  4
		.FILTER_RANGE(3'b001)	// FILTER_RANGE = 1
	) uut (
		.LOCK(locked),
		.RESETB(1'b1),
		.BYPASS(1'b0),
		.REFERENCECLK(clock_in),
		.PLLOUTCORE(clock_out),

		/* Unused */
		.PLLOUTGLOBAL(),
		.EXTFEEDBACK(),
		.LATCHINPUTVALUE(),
		.SDO(),
		.SDI(),
		.SCLK(),
		.DYNAMICDELAY()
		);

endmodule
```
